### PR TITLE
remove go 1.20 from version matrix

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.20', '1.21' ]
+        go-version: [ '1.21' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
removes go version 1.20 from go-version matrix on audit job because we don't use it