### PR TITLE
feat: build all package binaries at once

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Build
         if: github.event.directory == ''
         run: |
-          go build -v ./cmd/...
+          go build -v -o . ./cmd/...
 
       - name: Tag
         run: |


### PR DESCRIPTION
If there are multiple directories under `cmd/`, `go build` won't put any binaries into the current directory.

> The -o flag forces build to write the resulting executable or object
> to the named output file or directory, instead of the default behavior
> described in the last two paragraphs. If the named output is a directory
> that exists, then any resulting executables will be written to that
> directory.

https://stackoverflow.com/a/65705998

See https://github.com/planetmint/bdjuno/issues/4